### PR TITLE
fix a couple extended ascii chars in splash.ui

### DIFF
--- a/src/qt/pivx/forms/splash.ui
+++ b/src/qt/pivx/forms/splash.ui
@@ -161,7 +161,7 @@
 										</string>
 									</property>
 									<property name="text">
-										<string>Loadingâ€¦</string>
+										<string>Loading...</string>
 									</property>
 									<property name="alignment">
 										<set>Qt::AlignTop|Qt::AlignLeft</set>


### PR DESCRIPTION
This was not causing issues, but wanted to fix it just to be safe.

This is ready to merge into master.